### PR TITLE
Fix mean calculation in transform lambda

### DIFF
--- a/include/hdl_people_detection/marcel_people_detector.hpp
+++ b/include/hdl_people_detection/marcel_people_detector.hpp
@@ -150,7 +150,7 @@ private:
         for(const auto& pt : cloud->points) {
           mean += pt.getVector4fMap();
         }
-        return mean.head<2>();
+        return mean.head<2>() / static_cast<float>(cloud->size());
       }
     );
 


### PR DESCRIPTION
The previous implementation only computed the sum of points in each cloud, 
but failed to divide by the number of points to obtain the actual mean. 
This commit corrects the logic by dividing the accumulated sum by cloud->size(), 
ensuring the result is the true centroid (mean) of each point cloud.